### PR TITLE
Patch path joining for ripping

### DIFF
--- a/autorippr.py
+++ b/autorippr.py
@@ -143,7 +143,7 @@ def rip(config):
             disc_title = mkv_api.get_title()
             disc_type = mkv_api.get_type()
 
-            disc_path = '{}/{}'.format(mkv_save_path, disc_title)
+            disc_path = os.path.join(mkv_save_path, disc_title)
             if not os.path.exists(disc_path):
                 os.makedirs(disc_path)
 


### PR DESCRIPTION
.format was used isntead of os.path.join, created problems depending on
format of mkv move path in config file.